### PR TITLE
Refetch object on IntegrityError instead of masking as DoesNotExist

### DIFF
--- a/djstripe/models/base.py
+++ b/djstripe/models/base.py
@@ -803,7 +803,33 @@ class StripeModel(StripeBaseModel):
             # This is common during webhook handling, since Stripe sends
             # multiple webhook events simultaneously,
             # each of which will cause recursive syncs. See issue #429
-            return cls.stripe_objects.get(id=id_), False
+            try:
+                return cls.stripe_objects.get(id=id_), False
+            except cls.DoesNotExist:
+                # The IntegrityError was NOT a race condition: the object was
+                # never created. This happens when the object was built from
+                # incomplete nested data (e.g. an invoice line item embeds a
+                # partial Price that omits its required `product` FK), so the
+                # insert hit a NOT NULL / FK constraint. Refetch the canonical
+                # object from Stripe (which includes the missing fields) and
+                # create it properly, instead of masking it as a DoesNotExist.
+                if id_ is None:
+                    raise
+                data = cls(id=id_).api_retrieve(
+                    stripe_account=stripe_account, api_key=api_key
+                )
+                with transaction.atomic():
+                    return (
+                        cls._create_from_stripe_object(
+                            data,
+                            current_ids=current_ids,
+                            pending_relations=pending_relations,
+                            save=save,
+                            stripe_account=stripe_account,
+                            api_key=api_key,
+                        ),
+                        True,
+                    )
 
     @classmethod
     def _stripe_object_to_customer(


### PR DESCRIPTION
## Problem

When a nested object is built from **incomplete embedded data** — e.g. a Stripe **Invoice** webhook embeds a partial `Price` in its line items that omits the required `product` FK — `_stripe_object_to_record` skips the missing field and `_create_from_stripe_object` inserts a row with a null required FK. The DB raises `IntegrityError` (`NotNullViolation` on `djstripe_price.product_id`).

`_get_or_create_from_stripe_object` caught that `IntegrityError` assuming a **race condition** and retried `stripe_objects.get(id=...)`. Since the object was never created, `get()` raised `DoesNotExist`, which surfaced to the webhook handler as a misleading **500**:

```
djstripe.models.core.Price.DoesNotExist: Price matching query does not exist.
```

Observed in production on real, valid data: the price referenced an existing, active product (`product = "prod_..."`), but neither was synced locally, so every retry of that Invoice webhook 500'd.

## Fix

When the post-`IntegrityError` `get()` confirms the object still doesn't exist (i.e. it was **not** a race), refetch the canonical object from Stripe by id — which includes the fields the embedded copy was missing — and create it properly. Genuine race conditions still short-circuit on the first `get()`.

Only the error path changes; the happy path is untouched.

## Notes

Targeted at `stable/2.8` (the commit currently pinned by the consuming app). Not yet covered by a unit test — a djstripe-style test mocking `api_retrieve` to return a product-bearing price would be a good follow-up.